### PR TITLE
Fix the need for extra comment block

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -3,7 +3,8 @@
 *.iml
 
 # Built using tsc
-plugin.js 
+plugin.js
+getRawComment.js
 
 # Logs
 logs

--- a/README.md
+++ b/README.md
@@ -46,14 +46,12 @@ typedoc
 
 Add a comment block at the top of the file (ES6 module).
 Specify the Typedoc External Module using the `@module` annotation.
-A known issue: The comment block must be followed by another comment block for some reason (?).
 
 #### thing1/foo.ts
 ```js
 /**
  * @module thing1
  */
-/** second comment block */
 
 // foo stuff
 ```
@@ -62,7 +60,7 @@ A known issue: The comment block must be followed by another comment block for s
 ```js
 /**
  * @module thing1
- */ /** */
+ */
 
 // bar stuff
 ```
@@ -71,7 +69,7 @@ A known issue: The comment block must be followed by another comment block for s
 ```js
 /**
  * @module thing2
- */ /** */
+ */
 
 // baz stuff
 ```
@@ -86,7 +84,7 @@ To specify the which file's comment block will be used to document the Typedoc M
  * @preferred
  *
  * This comment will be used to document the "thing2" module.
- */ /** */
+ */
 
 // qux stuff
 ```

--- a/getRawComment.ts
+++ b/getRawComment.ts
@@ -1,0 +1,69 @@
+/**
+ * Contains `getRawComment` copied from typedoc but adjusted to avoid
+ * skipping over the only topmost jsdoc block
+ *
+ * @see https://github.com/christopherthielen/typedoc-plugin-external-module-name/issues/6
+ * @see https://github.com/TypeStrong/typedoc/blob/master/src/lib/converter/factories/comment.ts
+ */
+
+import * as ts from 'typescript';
+import * as _ts from 'typedoc/dist/lib/ts-internal';
+
+
+function isTopmostModuleDeclaration(node: ts.ModuleDeclaration): boolean {
+  if (node.nextContainer && node.nextContainer.kind === ts.SyntaxKind.ModuleDeclaration) {
+    let next = <ts.ModuleDeclaration>node.nextContainer;
+    if (node.name.end + 1 === next.name.pos) {
+      return false;
+    }
+  }
+
+  return true;
+}
+
+function getRootModuleDeclaration(node: ts.ModuleDeclaration): ts.Node {
+  while (node.parent && node.parent.kind === ts.SyntaxKind.ModuleDeclaration) {
+    let parent = <ts.ModuleDeclaration>node.parent;
+    if (node.name.pos === parent.name.end + 1) {
+      node = parent;
+    } else {
+      break;
+    }
+  }
+
+  return node;
+}
+
+export default function getRawComment(node: ts.Node): string {
+  if (node.parent && node.parent.kind === ts.SyntaxKind.VariableDeclarationList) {
+    node = node.parent.parent;
+  } else if (node.kind === ts.SyntaxKind.ModuleDeclaration) {
+    if (!isTopmostModuleDeclaration(<ts.ModuleDeclaration>node)) {
+      return null;
+    } else {
+      node = getRootModuleDeclaration(<ts.ModuleDeclaration>node);
+    }
+  }
+
+  const sourceFile = _ts.getSourceFileOfNode(node);
+  const comments = _ts.getJSDocCommentRanges(node, sourceFile.text);
+  if (comments && comments.length) {
+    let comment: ts.CommentRange;
+    if (node.kind === ts.SyntaxKind.SourceFile) {
+      /**
+       * This is what typedoc uses to skip over the topmost jsdoc block.
+       * We want to parse it to look for `@module` and `@preferred` annotations
+       */
+      // if (comments.length === 1) {
+      //   return null;
+      // }
+      comment = comments[0];
+    } else {
+      comment = comments[comments.length - 1];
+    }
+
+    return sourceFile.text.substring(comment.pos, comment.end);
+  } else {
+    return null;
+  }
+}

--- a/plugin.ts
+++ b/plugin.ts
@@ -4,7 +4,7 @@ import {Converter} from "typedoc/dist/lib/converter/converter";
 import {Context} from "typedoc/dist/lib/converter/context";
 import {CommentPlugin} from "typedoc/dist/lib/converter/plugins/CommentPlugin";
 import {ContainerReflection} from "typedoc/dist/lib/models/reflections/container";
-import {getRawComment} from "typedoc/dist/lib/converter/factories/comment";
+import getRawComment from "./getRawComment";
 
 
 /**

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -8,7 +8,8 @@
     "experimentalDecorators": true
   },
   "files": [
-    "plugin.ts"
+    "plugin.ts",
+    "getRawComment.ts"
   ],
   "exclude": [
     "node_modules"


### PR DESCRIPTION
Adapt `getRawComment` from `typedoc` to prevent skipping over the
topmost jsdoc block if only one such block is present.

Closes christopherthielen/typedoc-plugin-external-module-name#6