### PR TITLE
Allow " to be used in module names.

### DIFF
--- a/plugin.ts
+++ b/plugin.ts
@@ -67,7 +67,7 @@ export class ExternalModuleNamePlugin extends ConverterComponent
     if (reflection.kindOf(ReflectionKind.ExternalModule)) {
       let comment = getRawComment(node);
       // Look for @module
-      let match = /@module\s+([\w\-_/@]+)/.exec(comment);
+      let match = /@module\s+([\w\-_/@"]+)/.exec(comment);
       if (match) {
         // Look for @preferred
         let preferred = /@preferred/.exec(comment);


### PR DESCRIPTION
We used to have modules with external ambient module declarations, but now rely on the TypeScript module resolution to figure out .d.ts-es from file paths and module names. So we have to use this plugin but to keep the api-ref somewhat backward compatible (e.g. to still have an `"application"` module instead of `application` we need commas allowed in the module names.