### PR TITLE
Updated typedoc dependency

### DIFF
--- a/package.json
+++ b/package.json
@@ -18,7 +18,7 @@
   "author": "Chris Thielen",
   "license": "MIT",
   "peerDependencies": {
-    "typedoc": "^0.5.3"
+    "typedoc": "^0.8.0"
   },
   "devDependencies": {
     "@types/handlebars": "^4.0.31",

--- a/package.json
+++ b/package.json
@@ -4,7 +4,7 @@
   "description": "Specify the Typedoc Module of a file using @module annotation",
   "main": "index.js",
   "scripts": {
-    "build": "tsc",
+    "build": "node_modules/.bin/tsc",
     "prepublish": "npm run build"
   },
   "keywords": [
@@ -22,7 +22,7 @@
   },
   "devDependencies": {
     "@types/handlebars": "^4.0.31",
-    "typedoc": "^0.5.3",
-    "typescript": "^2.1.1"
+    "typedoc": "^0.8.0",
+    "typescript": "2.2.2"
   }
 }


### PR DESCRIPTION
This PR updates the typedoc dependency to ^0.8.0. This worked without a problem on my documentation.

I also replaced the "tsc" call in the build script with a node_modules-relative call, so a global typescript installation is not necessary.