### PR TITLE
Ensure compatibility with typedoc 0.14.2

### DIFF
--- a/package.json
+++ b/package.json
@@ -28,8 +28,8 @@
     "husky": "^2.2.0",
     "prettier": "^1.13.7",
     "pretty-quick": "^1.4.1",
-    "typedoc": "~0.11.1",
-    "typescript": "~2.7.2"
+    "typedoc": "~0.14.2",
+    "typescript": "~3.2.4"
   },
   "husky": {
     "hooks": {

--- a/plugin.ts
+++ b/plugin.ts
@@ -107,7 +107,7 @@ export class ExternalModuleNamePlugin extends ConverterComponent {
       for (let i = 0; i < nameParts.length - 1; ++i) {
         let child: DeclarationReflection = parent.children.filter(ref => ref.name === nameParts[i])[0];
         if (!child) {
-          child = new DeclarationReflection(parent, nameParts[i], ReflectionKind.ExternalModule);
+          child = new DeclarationReflection(nameParts[i], ReflectionKind.ExternalModule, parent);
           child.parent = parent;
           child.children = [];
           context.project.reflections[child.id] = child;


### PR DESCRIPTION
Fixes #332 by upgrading typedoc and consequently typescript, as well as updating the call to a typedoc class constructor.

I'm not familiar with the upgrade policy that you want to ensure, so feel completely free to advise on an alternative approach.