### PR TITLE
update deprecated removeTags & removeReflection

### DIFF
--- a/typedoc-plugin-external-module-name.ts
+++ b/typedoc-plugin-external-module-name.ts
@@ -84,8 +84,8 @@ export class ExternalModuleNamePlugin extends ConverterComponent {
     }
 
     if (reflection.comment) {
-      CommentPlugin.removeTags(reflection.comment, 'module');
-      CommentPlugin.removeTags(reflection.comment, 'preferred');
+      reflection.comment.removeTags('module');
+      reflection.comment.removeTags('preferred');
       if (isEmptyComment(reflection.comment)) {
         delete reflection.comment;
       }
@@ -171,8 +171,10 @@ export class ExternalModuleNamePlugin extends ConverterComponent {
       removeReflection(context, renaming);
 
       // Remove @module and @preferred from the comment, if found.
-      CommentPlugin.removeTags(mergeTarget.comment, 'module');
-      CommentPlugin.removeTags(mergeTarget.comment, 'preferred');
+      if (mergeTarget.comment) {
+        mergeTarget.comment.removeTags('module');
+        mergeTarget.comment.removeTags('preferred');
+      }
       if (isEmptyComment(mergeTarget.comment)) {
         delete mergeTarget.comment;
       }
@@ -181,7 +183,7 @@ export class ExternalModuleNamePlugin extends ConverterComponent {
 }
 
 function removeReflection(context: Context, reflection: Reflection) {
-  CommentPlugin.removeReflection(context.project, reflection);
+  context.project.removeReflection(reflection, true);
   if (isTypedocVersion('>=0.16.0')) {
     delete context.project.reflections[reflection.id];
   }


### PR DESCRIPTION
I’m getting console warnings when I run this plugin using typedoc v0.17+.

> Using deprecated function removeTags. This function will be removed in the next minor release.
> Using deprecated function removeReflections. This function will be removed in the next minor release.

These warnings are found here:

https://github.com/TypeStrong/typedoc/blob/2e63096dd34be61bfbd2062a0ac75796e55a037d/src/lib/converter/plugins/CommentPlugin.ts#L360-L388

The documentation says to use the instance methods `Comment#removeTags` and `ProjectReflection#removeReflection` instead.

Feel free to amend this PR as necessary.