### PR TITLE
Avoid errors on typescript interfaces.

### DIFF
--- a/typedoc-plugin-external-module-name.ts
+++ b/typedoc-plugin-external-module-name.ts
@@ -193,6 +193,10 @@ function removeReflection(context: Context, reflection: Reflection) {
  * https://github.com/christopherthielen/typedoc-plugin-external-module-name/issues/193
  */
 function updateSymbolMapping(context: Context, symbol: ts.Symbol, reflection: Reflection) {
+  if (!symbol) {
+    return;
+  }
+  
   if (isTypedocVersion('< 0.16.0')) {
     // (context as any).registerReflection(reflection, null, symbol);
     (context.project as any).symbolMapping[(symbol as any).id] = reflection.id;


### PR DESCRIPTION
When adding d.ts files with commented interfaces, there is no symbol (it's undefined), and there is an error

```
Cannot read property 'parent' of undefined
```

This avoids the error.