### PR TITLE
Fix module @preferred parameter to work correctly

### DIFF
--- a/typedoc-plugin-external-module-name.ts
+++ b/typedoc-plugin-external-module-name.ts
@@ -148,7 +148,7 @@ export class ExternalModuleNamePlugin extends ConverterComponent {
         // Set up a list of renames operations to perform when the resolve phase starts
         this.moduleRenames.push({
           renameTo: moduleName,
-          preferred: preferred != null,
+          preferred: !!preferred,
           symbol: node.symbol,
           reflection: <ContainerReflection>reflection,
         });


### PR DESCRIPTION
There is a wrong condition for `@preferred` parameter while forming `modulerRanames`. `@preferred` parameters work as opposite, and module with this parameter will be treated with lower priority. 