### PR TITLE
feat: support typedoc 0.19

### DIFF
--- a/package.json
+++ b/package.json
@@ -24,7 +24,7 @@
     "semver": "^7.1.1"
   },
   "peerDependencies": {
-    "typedoc": ">=0.7.0 <0.18.0"
+    "typedoc": ">=0.7.0 <0.20.0"
   },
   "devDependencies": {
     "@types/handlebars": "^4.0.37",


### PR DESCRIPTION
just changes the peer dep range in  package.json 